### PR TITLE
query statement refactoring

### DIFF
--- a/native/src/main.rs
+++ b/native/src/main.rs
@@ -123,8 +123,9 @@ fn execute_statement(conn: &Connection, sql: &str, values: &[ErlangValue]) -> Re
 }
 
 fn query_statement(conn: &Connection, sql: &str, values: &[ErlangValue]) -> Response {
-    let Ok(mut stmt) = conn.prepare(sql) else {
-        return Response::error(format!("SQL preparation error: {}", sql));
+    let mut stmt = match conn.prepare(sql) {
+        Ok(stmt) => stmt,
+        Err(e) => return Response::error(format!("SQL preparation error: {}\n\n{}", e, sql)),
     };
 
     let mut all_rows = Vec::new();


### PR DESCRIPTION
- Retrieve values with a single iteration through the rows.
- Propagate error if column retrieval failed.
- Preallocate a vector for the row.
