### PR TITLE
Fix the mix dependency definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `duckex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:duckex, github: "http://github.com/promeduck/duckex"}
+    {:duckex, github: "promeduck/duckex"}
   ]
 end
 ```


### PR DESCRIPTION
Currently the Readme suggest to load repo from

```
https://github.com/https://github.com/promeduck/duckex
```

Which of course fails.